### PR TITLE
CAF-3708: Updated to log to the standard output streams

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -18,7 +18,7 @@
 # Preliminary image that downloads Tomcat and makes some modifications
 #
 FROM opensuse:latest AS builder
-RUN zypper -n install tar
+RUN zypper -n install tar xsltproc
 WORKDIR /usr/share/
 ADD http://apache.mirrors.lucidnetworks.net/tomcat/tomcat-8/v8.5.23/bin/apache-tomcat-8.5.23.tar.gz .
 RUN tar xzf apache-tomcat-8.5.23.tar.gz
@@ -29,6 +29,11 @@ RUN rm -rf webapps/docs/ webapps/examples/ webapps/host-manager/ webapps/manager
 # (It is being copied to a temporary folder first, and then overwritten using cp, in order to retain the original file's permissions.)
 COPY logging.properties /tmp/tomcat/conf/
 RUN cp /tmp/tomcat/conf/logging.properties conf/
+
+# Apply the specified transform to the server.xml file
+COPY server.xslt /tmp/tomcat/conf/
+RUN cp conf/server.xml /tmp/tomcat/conf/
+RUN xsltproc -o conf/server.xml /tmp/tomcat/conf/server.xslt /tmp/tomcat/conf/server.xml
 
 #
 # The actual image definition

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -25,6 +25,11 @@ RUN tar xzf apache-tomcat-8.5.23.tar.gz
 WORKDIR apache-tomcat-8.5.23/
 RUN rm -rf webapps/docs/ webapps/examples/ webapps/host-manager/ webapps/manager/
 
+# Overwrite the main logging configuration file
+# (It is being copied to a temporary folder first, and then overwritten using cp, in order to retain the original file's permissions.)
+COPY logging.properties /tmp/tomcat/conf/
+RUN cp /tmp/tomcat/conf/logging.properties conf/
+
 #
 # The actual image definition
 #

--- a/src/main/docker/logging.properties
+++ b/src/main/docker/logging.properties
@@ -14,22 +14,14 @@
 # limitations under the License.
 #
 
-handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+handlers = java.util.logging.ConsoleHandler
 
-.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+.handlers = java.util.logging.ConsoleHandler
 
 ############################################################
 # Handler specific properties.
 # Describes specific configuration info for Handlers.
 ############################################################
-
-1catalina.org.apache.juli.AsyncFileHandler.level = FINE
-1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
-
-2localhost.org.apache.juli.AsyncFileHandler.level = FINE
-2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
 
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
@@ -41,7 +33,7 @@ java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 ############################################################
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler
 
 # For example, set the org.apache.catalina.util.LifecycleBase logger to log
 # each component that extends LifecycleBase changing state:

--- a/src/main/docker/logging.properties
+++ b/src/main/docker/logging.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
 
 .handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
 
@@ -31,14 +31,6 @@ handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.jul
 2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
 2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
 
-3manager.org.apache.juli.AsyncFileHandler.level = FINE
-3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
-
-4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
-4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
-4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
-
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 
@@ -50,12 +42,6 @@ java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
 org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
-
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
-
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
-org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
 
 # For example, set the org.apache.catalina.util.LifecycleBase logger to log
 # each component that extends LifecycleBase changing state:

--- a/src/main/docker/logging.properties
+++ b/src/main/docker/logging.properties
@@ -24,6 +24,7 @@ handlers = java.util.logging.ConsoleHandler
 ############################################################
 
 java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.encoding = UTF-8
 java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
 
 

--- a/src/main/docker/logging.properties
+++ b/src/main/docker/logging.properties
@@ -1,0 +1,71 @@
+#
+# Copyright 2015-2017 EntIT Software LLC, a Micro Focus company.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = FINE
+1catalina.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+
+2localhost.org.apache.juli.AsyncFileHandler.level = FINE
+2localhost.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
+
+3manager.org.apache.juli.AsyncFileHandler.level = FINE
+3manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
+
+4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
+4host-manager.org.apache.juli.AsyncFileHandler.directory = ${catalina.base}/logs
+4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+#org.apache.catalina.util.LifecycleBase.level = FINE
+
+# To see debug messages in TldLocationsCache, uncomment the following line:
+#org.apache.jasper.compiler.TldLocationsCache.level = FINE
+
+# To see debug messages for HTTP/2 handling, uncomment the following line:
+#org.apache.coyote.http2.level = FINE
+
+# To see debug messages for WebSocket handling, uncomment the following line:
+#org.apache.tomcat.websocket.level = FINE

--- a/src/main/docker/server.xslt
+++ b/src/main/docker/server.xslt
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright 2015-2017 EntIT Software LLC, a Micro Focus company.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes" />
+
+    <!-- Copy the entire xml file -->
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Override the specified access logging element -->
+    <xsl:template match="/Server/Service[@name='Catalina']/Engine[@name='Catalina']/Host[@name='localhost']/Valve[@className='org.apache.catalina.valves.AccessLogValve']">
+        <xsl:copy>
+            <xsl:attribute name="className">
+                <xsl:value-of select="@className" />
+            </xsl:attribute>
+            <xsl:attribute name="directory">/dev</xsl:attribute>
+            <xsl:attribute name="prefix">stdout</xsl:attribute>
+            <xsl:attribute name="rotatable">false</xsl:attribute>
+            <xsl:attribute name="pattern">access_log> <xsl:value-of select="@pattern" /></xsl:attribute>
+            <xsl:attribute name="encoding">UTF-8</xsl:attribute>
+            <xsl:attribute name="buffered">false</xsl:attribute>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-3708

A developer build for this has been created:
http://sou-jenkins2.hpeswlab.net/job/CAFapi/view/Developer/job/CAFapi~opensuse-tomcat-image~logging~CI/

It can be tested using this image:

    docker image pull cafinternal/prereleases:opensuse-tomcat-1.1.0-logging-SNAPSHOT
