### PR TITLE
Fix SCMOD-9686

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target/
 **/target/
+.settings/
+.vscode/
+.project
+.classpath

--- a/caf-logging-tomcat-juli/pom.xml
+++ b/caf-logging-tomcat-juli/pom.xml
@@ -142,6 +142,8 @@
                                     <artifact>org.apache.tomcat:tomcat-juli</artifact>
                                     <includes>
                                         <include>org/apache/juli/ClassLoaderLogManager**</include>
+                                        <include>org/apache/juli/FileHandler**</include>
+                                        <include>org/apache/juli/AsyncFile**</include>
                                         <include>org/apache/juli/WebappProperties.class</include>
                                         <include>META-INF/LICENSE</include>
                                         <include>META-INF/NOTICE</include>


### PR DESCRIPTION
Update the` maven-shade-plugin` filter to include the `AsyncFileHandler` classes and their dependencies. This allows the AsyncFileHandler class to be instantiated without a ClassNotFoundException.