### PR TITLE
SCMOD-9768: Updated to tomcat 9.0.35

### DIFF
--- a/opensuse-tomcat-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-image/src/main/docker/Dockerfile
@@ -29,11 +29,11 @@ ENV TOMCAT_BIN_DIR $TOMCAT_ROOT_DIR/bin
 ENV TOMCAT_LIB_DIR $TOMCAT_ROOT_DIR/lib
 
 # Extract Tomcat and remove unwanted web applications
-COPY apache-tomcat-9.0.26.tar.gz .
+COPY apache-tomcat-9.0.35.tar.gz .
 RUN mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-9.0.26.tar.gz && \
-    mv apache-tomcat-9.0.26 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-9.0.35.tar.gz && \
+    mv apache-tomcat-9.0.35 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf $TOMCAT_CONF_DIR/logging.properties docs/ examples/ host-manager/ manager/
 

--- a/release-notes-5.0.0.md
+++ b/release-notes-5.0.0.md
@@ -6,6 +6,7 @@ ${version-number}
 #### New Features
 - **SCMOD-8516**: Extend the security hardening of Java base images by disabling TLS algorithms mentioned [here](https://github.com/CAFapi/opensuse-java8-images/blob/develop/src/main/docker/disableWeakTlsAlgorithms.patch)  
 - **SCMOD-9686**: Included additional classes [FileHandler](https://tomcat.apache.org/tomcat-9.0-doc/api/org/apache/juli/FileHandler.html) and [AsyncFile](https://tomcat.apache.org/tomcat-9.0-doc/api/org/apache/juli/AsyncFileHandler.html) from `tomcat-juli.jar`.
+- **SCMOD-9768**: Updated Tomcat to version 9.0.35
 
 #### Known Issues
 - None


### PR DESCRIPTION
- JIRA: https://portal.digitalsafe.net/browse/SCMOD-9768
- GitHub Issue: https://github.com/CAFapi/opensuse-tomcat-image/issues/32