### PR TITLE
SCMOD-13334: Restore OneLineFormatter classes to tomcat-juli.jar

### DIFF
--- a/caf-logging-tomcat-juli/pom.xml
+++ b/caf-logging-tomcat-juli/pom.xml
@@ -144,6 +144,7 @@
                                         <include>org/apache/juli/ClassLoaderLogManager**</include>
                                         <include>org/apache/juli/FileHandler**</include>
                                         <include>org/apache/juli/AsyncFile**</include>
+                                        <include>org/apache/juli/OneLineFormatter**</include>
                                         <include>org/apache/juli/WebappProperties.class</include>
                                         <include>META-INF/LICENSE</include>
                                         <include>META-INF/NOTICE</include>


### PR DESCRIPTION
Right now, when placing `tomcat/lib/postgresql.jar`,  tomcat startup can load, but not find at runtime `org.postgresql.Driver`, resulting in `java.lang.NoClassDefFoundError` (see [issue #41](https://github.com/CAFapi/opensuse-tomcat-image/issues/41#)). 

This PR is to fix that. Apparently just restoring `OneLineFormatter` from the `tomcat-juli.jar` to the (uber) `tomcat-juli.jar` is all that is needed to get past that error.