### PR TITLE
SCMOD-13983: Update tomcat to 9.0.46

### DIFF
--- a/opensuse-tomcat-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-image/src/main/docker/Dockerfile
@@ -32,11 +32,11 @@ ENV TOMCAT_BIN_DIR $TOMCAT_ROOT_DIR/bin
 ENV TOMCAT_LIB_DIR $TOMCAT_ROOT_DIR/lib
 
 # Extract Tomcat and remove unwanted web applications
-COPY apache-tomcat-9.0.38.tar.gz .
+COPY apache-tomcat-9.0.46.tar.gz .
 RUN mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-9.0.38.tar.gz && \
-    mv apache-tomcat-9.0.38 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-9.0.46.tar.gz && \
+    mv apache-tomcat-9.0.46 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf $TOMCAT_CONF_DIR/logging.properties docs/ examples/ host-manager/ manager/
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dockerCafImagePrefix>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerCafImagePrefix>
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
         <logbackVersion>1.2.3</logbackVersion>
-        <tomcatVersion>9.0.38</tomcatVersion>
+        <tomcatVersion>9.0.46</tomcatVersion>
     </properties>
 
     <dependencyManagement>

--- a/release-notes-5.4.0.md
+++ b/release-notes-5.4.0.md
@@ -6,6 +6,7 @@ ${version-number}
 #### New Features
 - The image is now based on [openSUSE Leap 15.3](https://en.opensuse.org/Portal:15.3).  
 The release notes for openSUSE Leap 15.3 can be found [here](https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.3/).
+- SCMOD-13983: Tomcat updated to version [9.0.46](https://mirrors.ukfast.co.uk/sites/ftp.apache.org/tomcat/tomcat-9/v9.0.46/README.html).
 
 #### Bug fixes
  - SCMOD-13334: [Tomcat Base Image Issue #41](https://github.com/CAFapi/opensuse-tomcat-image/issues/41): Tomcat-Juli Jar Causes java.lang.NoClassDefFoundError: Could not initialize class org.postgresql.Driver


### PR DESCRIPTION
I noticed that the current version (9.0.38) of tomcat is over a year old so thought I would update it.