### PR TITLE
US590035: Code review of #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,12 @@
 # openSUSE with Java and Tomcat image
 
-This project consists of 2 separate images which build on the openSUSE Java 8 image [here](https://github.com/CAFapi/opensuse-java8-images) 
-to build two pre-configured Tomcat.
+This project builds on the openSUSE Java 8 image [here](https://github.com/CAFapi/opensuse-java8-images) to build two pre-configured
+Tomcat Docker images that use two logging frameworks.  One of the images uses the Logback logging framework and the other that uses
+Tomcat JULI logging.
 
-One that uses CAF Logging framework and the other that relies on Tomcat Juli logging.
+They can be used as base images for hosting web projects which use Java technologies such as Java Servlets or JavaServer Pages.
 
-Each one can be used as a base image for hosting web projects which use Java technologies such as Java Servlets or JavaServer Pages.
-
-Here is an example Dockerfile which uses the image with Tomcat Juli logging as a base:
-
-    FROM cafapi/opensuse-tomcat-juli:latest
-
-    COPY demowebapp/ $CATALINA_HOME/webapps/demowebapp/
-    COPY demowebapp-admin/ $CATALINA_HOME/adminapps/ROOT/
-
-Here is an example Dockerfile which uses the image with CAF Logging as a base:
+Here is an example Dockerfile which uses one of the images as a base:
 
     FROM cafapi/opensuse-tomcat:latest
 

--- a/opensuse-tomcat-image/pom.xml
+++ b/opensuse-tomcat-image/pom.xml
@@ -106,7 +106,7 @@
                             <name>${dockerCafImagePrefix}opensuse-tomcat${dockerProjectVersion}</name>
                             <build>
                                 <dockerFileDir>.</dockerFileDir>
-                                <assembly>
+                                 <assembly>
                                     <basedir>/</basedir>
                                     <inline>
                                         <dependencySets>
@@ -122,6 +122,7 @@
                                     <http_proxy>${env.HTTP_PROXY}</http_proxy>
                                     <https_proxy>${env.HTTPS_PROXY}</https_proxy>
                                     <no_proxy>${env.NO_PROXY}</no_proxy>
+
                                     <!-- Pass in opensuse-tomcat-juli image as param -->
                                     <JULI_IMAGE>${dockerCafImagePrefix}opensuse-tomcat-juli${dockerProjectVersion}</JULI_IMAGE>
                                 </args>

--- a/opensuse-tomcat-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-image/src/main/docker/Dockerfile
@@ -17,12 +17,15 @@
 # Docker registry
 ARG DOCKER_HUB_PUBLIC=docker.io
 
-#OpenSUSE Tomcat Base image
+#
+# Preliminary image, makes some modifications to the JULI image
+#
 ARG JULI_IMAGE
 FROM $JULI_IMAGE AS builder
-RUN zypper -n install xsltproc
-ENV CATALINA_HOME /usr/share/tomcat
 
+RUN zypper -n install xsltproc
+
+ENV CATALINA_HOME /usr/share/tomcat
 ENV CATALINA_CONF_DIR $CATALINA_HOME/conf
 ENV CATALINA_BIN_DIR $CATALINA_HOME/bin
 ENV CATALINA_LIB_DIR $CATALINA_HOME/lib
@@ -31,7 +34,8 @@ ENV PATH $CATALINA_BIN_DIR:$PATH
 
 WORKDIR $CATALINA_HOME
 
-RUN rm -rf $CATALINA_CONF_DIR/logging.properties
+RUN rm -rf $CATALINA_CONF_DIR/logging.properties \
+           /startup/startup.d/setup-loglevel.sh
 
 # Copy new logback.xml and logback-access.xml to tomcat conf folder for logback implementation
 COPY logback*.xml $CATALINA_CONF_DIR/
@@ -41,16 +45,18 @@ COPY setenv.* $CATALINA_BIN_DIR/
 
 # Copy a new lib folder with thirdparty jars for logback implementation to tomcat lib folder
 COPY /maven/lib/*.jar $CATALINA_LIB_DIR/
-RUN mv lib/caf-logging-tomcat-juli-*.jar bin/tomcat-juli.jar
+RUN mv $CATALINA_LIB_DIR/caf-logging-tomcat-juli-*.jar $CATALINA_BIN_DIR/tomcat-juli.jar
 
 # Apply the specified transform to the server.xml file
 COPY server.xslt .
-RUN xsltproc -o $CATALINA_CONF_DIR/server.xml server.xslt $CATALINA_CONF_DIR/server.xml
+RUN xsltproc -o $CATALINA_CONF_DIR/server.xml server.xslt $CATALINA_CONF_DIR/server.xml && \
+    rm server.xslt
 
 ENV WDBUILDER /wd/root
 
 RUN mkdir -p $WDBUILDER/usr/share && \
-    cp -R /startup $WDBUILDER && \
+    mkdir -p $WDBUILDER/startup/startup.d && \
+    cp /startup/startup.d/setup-tomcat* $WDBUILDER/startup/startup.d && \
     cp -R $CATALINA_HOME $WDBUILDER/usr/share
 
 #

--- a/opensuse-tomcat-image/src/main/docker/server.xslt
+++ b/opensuse-tomcat-image/src/main/docker/server.xslt
@@ -25,21 +25,16 @@
             <xsl:apply-templates select="@* | node()"/>
         </xsl:copy>
     </xsl:template>
-    
-    <xsl:template match="/Server/Service[@name='Catalina']/Connector[@port='8080']">
-        <xsl:copy>
-            <xsl:apply-templates select="@* | node()"/>
-        </xsl:copy>
-    </xsl:template>
 
-    <!-- Override the specified access logging element -->
+    <!-- Override the main application access logging element -->
     <xsl:template match="/Server/Service[@name='Catalina']/Engine[@name='Catalina']/Host[@name='localhost']/Valve[@className='org.apache.catalina.valves.AccessLogValve']">
         <xsl:copy>
             <xsl:attribute name="className">ch.qos.logback.access.tomcat.LogbackValve</xsl:attribute>
             <xsl:attribute name="quiet">true</xsl:attribute>
         </xsl:copy>
     </xsl:template>
-    <!-- Override the logging valve from the base image -->
+
+    <!-- Override the admin application access logging element -->
     <xsl:template match="/Server/Service[@name='CatalinaAdmin']/Engine[@name='CatalinaAdmin']/Host[@name='localhost']/Valve[@className='org.apache.catalina.valves.AccessLogValve']">
         <xsl:copy>
             <xsl:attribute name="className">ch.qos.logback.access.tomcat.LogbackValve</xsl:attribute>

--- a/opensuse-tomcat-juli-image/pom.xml
+++ b/opensuse-tomcat-juli-image/pom.xml
@@ -16,17 +16,22 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.github.cafapi.opensuse.tomcat</groupId>
         <artifactId>opensuse-tomcat-image-aggregator</artifactId>
         <version>5.7.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>opensuse-tomcat-juli-image</artifactId>
     <packaging>pom</packaging>
     
-    <name>openSUSE Tomcat Juli image</name>
+    <name>openSUSE Tomcat JULI image</name>
+
     <properties>
         <maven.install.skip>true</maven.install.skip>
         <DOCKER_HUB_PUBLIC>${dockerHubPublic}</DOCKER_HUB_PUBLIC>

--- a/opensuse-tomcat-juli-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-juli-image/src/main/docker/Dockerfile
@@ -68,6 +68,6 @@ WORKDIR $CATALINA_HOME
 HEALTHCHECK CMD curl --fail http://localhost:8081/healthcheck || exit 1
 
 EXPOSE 8080 8081 8443
-CMD ["catalina.sh", "run"] 
+CMD ["catalina.sh", "run"]
 
 COPY --from=builder /wd/root/ /

--- a/opensuse-tomcat-juli-image/src/main/docker/server.xslt
+++ b/opensuse-tomcat-juli-image/src/main/docker/server.xslt
@@ -53,7 +53,7 @@
     setup-tomcat-ssl-cert.sh TLS section end </xsl:comment><xsl:text>
     </xsl:text>
     </xsl:template>
-    
+
     <!-- Override the specified access logging element -->
     <xsl:template match="/Server/Service[@name='Catalina']/Engine[@name='Catalina']/Host[@name='localhost']/Valve[@className='org.apache.catalina.valves.AccessLogValve']">
         <xsl:copy>
@@ -63,9 +63,7 @@
             <xsl:attribute name="directory">/dev</xsl:attribute>
             <xsl:attribute name="prefix">stderr</xsl:attribute>
             <xsl:attribute name="rotatable">false</xsl:attribute>
-            <xsl:attribute name="pattern">
-                <xsl:value-of select="@pattern" />
-            </xsl:attribute>
+            <xsl:attribute name="pattern"><xsl:value-of select="@pattern" /></xsl:attribute>
             <xsl:attribute name="encoding">UTF-8</xsl:attribute>
             <xsl:attribute name="buffered">false</xsl:attribute>
         </xsl:copy>

--- a/opensuse-tomcat-juli-image/src/main/docker/startup.d/setup-loglevel.sh
+++ b/opensuse-tomcat-juli-image/src/main/docker/startup.d/setup-loglevel.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright 2017-2022 Micro Focus or one of its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script replaces the log level value in logging.properties if environment variable CAF_LOG_LEVEL is set
+#
+#Declare and initialize associative array. This is a mapping of log4j2 levels with that of java.util.logging
+declare -A LOG4J2TOJAVAmap=([FATAL]=SEVERE [ERROR]=SEVERE [WARN]=WARNING [DEBUG]=FINE [TRACE]=FINEST)
+if [ -n "${CAF_LOG_LEVEL}" ]
+then
+    #if CAF_LOG_LEVEL is not set right we default it to INFO
+    LOGLEVEL=INFO
+    if [ -n "${LOG4J2TOJAVAmap[${CAF_LOG_LEVEL^^}]}" ]
+    then
+        LOGLEVEL=${LOG4J2TOJAVAmap[${CAF_LOG_LEVEL^^}]}
+    fi
+    echo "Environment log level variable set CAF_LOG_LEVEL:${CAF_LOG_LEVEL}"
+    echo "Replacing log level in $CATALINA_HOME/conf/logging.properties with equivalent log level:${LOGLEVEL}"
+    sed -i "/org\.apache\.catalina\.core\.ContainerBase\.\[Catalina\]\.\[localhost\]\.level =/ s/=.*/= ${LOGLEVEL}/" \
+        $CATALINA_HOME/conf/logging.properties
+fi

--- a/release-notes-5.7.0.md
+++ b/release-notes-5.7.0.md
@@ -4,6 +4,6 @@
 ${version-number}
 
 #### New Features
-- US590035: There are now two images generated,  one image configured with CAF Logging, the other image falls back to Tomcat JULI logging
+- US590035: An additional image that uses Tomcat JULI logging has been added.
 
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=590035

These are some changes that I'd like to make to #59.  They look like more than they really are.  Some are just to avoid whitespace changes when we merge the main PR.  There are only very minor changes to the two images:

The logback image:
- Dropped the 3 startup files that are already in the base image rather than overwriting them with the same files
- Dropped the server.xslt file from the tomcat folder (it shouldn't be there obviously)

The Juli image:
- Added the setup-loglevel.sh script back in (from when we were originally using Juli)