### PR TITLE
US788018: Update to tomcat 9.0.76

### DIFF
--- a/caf-logging-tomcat-juli/pom.xml
+++ b/caf-logging-tomcat-juli/pom.xml
@@ -99,7 +99,7 @@
                                 <artifactItem>
                                     <groupId>com.github.tomcat-slf4j-logback</groupId>
                                     <artifactId>tomcat9-slf4j-logback</artifactId>
-                                    <version>9.0.76</version>
+                                    <version>${tomcatVersion}</version>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/tomcat9-slfj4-logback</outputDirectory>
                                 </artifactItem>

--- a/caf-logging-tomcat-juli/pom.xml
+++ b/caf-logging-tomcat-juli/pom.xml
@@ -99,7 +99,7 @@
                                 <artifactItem>
                                     <groupId>com.github.tomcat-slf4j-logback</groupId>
                                     <artifactId>tomcat9-slf4j-logback</artifactId>
-                                    <version>${tomcatVersion}</version>
+                                    <version>9.0.76</version>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/tomcat9-slfj4-logback</outputDirectory>
                                 </artifactItem>

--- a/opensuse-tomcat-juli-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-juli-image/src/main/docker/Dockerfile
@@ -30,11 +30,11 @@ ENV TOMCAT_ROOT_DIR $TOMCAT_PARENT_DIR/$TOMCAT_DIR_NAME
 ENV TOMCAT_CONF_DIR $TOMCAT_ROOT_DIR/conf
 
 # Extract Tomcat and remove unwanted web applications
-COPY apache-tomcat-9.0.73.tar.gz .
+COPY apache-tomcat-9.0.80.tar.gz .
 RUN mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-9.0.73.tar.gz && \
-    mv apache-tomcat-9.0.73 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-9.0.80.tar.gz && \
+    mv apache-tomcat-9.0.80 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf docs/ examples/ host-manager/ manager/
 

--- a/opensuse-tomcat-juli-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-juli-image/src/main/docker/Dockerfile
@@ -30,11 +30,11 @@ ENV TOMCAT_ROOT_DIR $TOMCAT_PARENT_DIR/$TOMCAT_DIR_NAME
 ENV TOMCAT_CONF_DIR $TOMCAT_ROOT_DIR/conf
 
 # Extract Tomcat and remove unwanted web applications
-COPY apache-tomcat-9.0.80.tar.gz .
+COPY apache-tomcat-9.0.76.tar.gz .
 RUN mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-9.0.80.tar.gz && \
-    mv apache-tomcat-9.0.80 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-9.0.76.tar.gz && \
+    mv apache-tomcat-9.0.76 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf docs/ examples/ host-manager/ manager/
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dockerCafImagePrefix>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerCafImagePrefix>
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
         <logbackVersion>1.2.3</logbackVersion>
-        <tomcatVersion>9.0.80</tomcatVersion>
+        <tomcatVersion>9.0.76</tomcatVersion>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dockerCafImagePrefix>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerCafImagePrefix>
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
         <logbackVersion>1.2.3</logbackVersion>
-        <tomcatVersion>9.0.73</tomcatVersion>
+        <tomcatVersion>9.0.80</tomcatVersion>
     </properties>
 
     <dependencyManagement>

--- a/release-notes-5.11.0.md
+++ b/release-notes-5.11.0.md
@@ -4,6 +4,6 @@
 ${version-number}
 
 #### New Features
-- US788018: Tomcat updated to version [9.0.80](https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.80/README.html).
+- US788018: Tomcat updated to version [9.0.76](https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.76/README.html).
 
 #### Known Issues

--- a/release-notes-5.11.0.md
+++ b/release-notes-5.11.0.md
@@ -4,5 +4,6 @@
 ${version-number}
 
 #### New Features
+- US788018: Tomcat updated to version [9.0.80](https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.80/README.html).
 
 #### Known Issues


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=788018

@dermot-hardy Not sure what to do about the latest tomcat9-slf4j-logback being 9.0.76 and not 9.0.80. I have hardcoded it to 9.0.76 below to get this to build, let me know what you think. You can see in [maven](https://mvnrepository.com/artifact/com.github.tomcat-slf4j-logback/tomcat9-slf4j-logback) that the latest available is 9.0.76.