### PR TITLE
Update Tomcat to 9.0.96

### DIFF
--- a/opensuse-tomcat-image/pom.xml
+++ b/opensuse-tomcat-image/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.34.0</version>
+                <version>0.40.2</version>
                 <executions>
                     <execution>
                         <id>docker-build</id>

--- a/opensuse-tomcat-juli-image/pom.xml
+++ b/opensuse-tomcat-juli-image/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.34.0</version>
+                <version>0.40.2</version>
                 <executions>
                     <execution>
                         <id>docker-build</id>

--- a/opensuse-tomcat-juli-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-juli-image/src/main/docker/Dockerfile
@@ -27,13 +27,13 @@ ENV TOMCAT_ROOT_DIR $TOMCAT_PARENT_DIR/$TOMCAT_DIR_NAME
 ENV TOMCAT_CONF_DIR $TOMCAT_ROOT_DIR/conf
 
 # Download, extract Tomcat and remove unwanted web applications
-RUN curl -fsSL -o /wd/apache-tomcat-9.0.87.tar.gz https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.87/bin/apache-tomcat-9.0.87.tar.gz && \
-    echo 71a64fe805aab89ef4798571d860a3c9a4f751f808921559a9249305abb205836de33ab89bb33b625a77f799f193d6bffbe94aadf293866df756d708f5bfb933 \
-        /wd/apache-tomcat-9.0.87.tar.gz | sha512sum -c - && \
+RUN curl -fsSL -o /wd/apache-tomcat-9.0.96.tar.gz https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.96/bin/apache-tomcat-9.0.96.tar.gz && \
+    echo ef3ac81debbc3a519c43d1fdb1c88ab26a8052af424d81bceccfbd6e663050a06d7aad7960fd5d11c17849829daebbebf33d92ac1158902283d0e534514aab93 \
+        /wd/apache-tomcat-9.0.96.tar.gz | sha512sum -c - && \
     mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-9.0.87.tar.gz && \
-    mv apache-tomcat-9.0.87 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-9.0.96.tar.gz && \
+    mv apache-tomcat-9.0.96 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf docs/ examples/ host-manager/ manager/
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dockerCafImagePrefix>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerCafImagePrefix>
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
         <logbackVersion>1.2.3</logbackVersion>
-        <tomcatVersion>9.0.87</tomcatVersion>
+        <tomcatVersion>9.0.96</tomcatVersion>
         <projectDockerRegistry>opensuse-tomcat-image-${project.version}.project-registries.local</projectDockerRegistry>
     </properties>
 

--- a/release-notes-5.17.0.md
+++ b/release-notes-5.17.0.md
@@ -5,4 +5,6 @@ ${version-number}
 
 #### New Features
 
+- Update to Tomcat 9.0.96
+
 #### Known Issues


### PR DESCRIPTION
## Overview

This change mitigates a CVE found in Tomcat 9.0.87 by updating to 9.0.96.

## Reference links

- [NVD - CVE-2024-34750](https://nvd.nist.gov/vuln/detail/CVE-2024-34750)